### PR TITLE
Switch order of upserting for config dictionary

### DIFF
--- a/src/server/anot8_vault_config.py
+++ b/src/server/anot8_vault_config.py
@@ -49,8 +49,8 @@ def upsert_anot8_vault_config (local_vault_config):
         raise Exception(result[1] + " in " + anot8_vault_config_file_path)
 
     vault_config = {
+        **anot8_vault_config,
         **local_vault_config,
-        **anot8_vault_config
     }
 
     return vault_config


### PR DESCRIPTION
local config values now take precedence

Note:  Only modifies the second upsert not the first, since I'm not clear enough on the intent of the first to modify it (and it's not necessary to achieve my goal of loading local files).